### PR TITLE
Correct contributors years

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,6 @@ please visit our [HALL_OF_FAME.md](HALL_OF_FAME.md).
 This program is free software: you can redistribute it and/or modify it
 under the terms of the [MIT license](LICENSE). OWASP Juice Shop CTF
 Extension and any contributions are Copyright © by Bjoern Kimminich &
-the OWASP Juice Shop contributors 2016-2021.
+the OWASP Juice Shop contributors 2014-2021.
 
 ![Juice Shop CTF Logo](https://raw.githubusercontent.com/juice-shop/juice-shop-ctf/develop/images/JuiceShopCTF_Logo_400px.png)


### PR DESCRIPTION
When viewing the licensing section at https://owasp.org/www-project-juice-shop/, the years that the contributors have are different and should reflect owasp.