### PR TITLE
Added functionallity to ignore certificate warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Optionally you can also choose the name of the output file:
 juice-shop-ctf --config myconfig.yml --output challenges.out
 ```
 
+You can ignore certificate warnings like this:
+
+```
+juice-shop-ctf --ignoreSslWarnings
+```
+
 ### Docker Container [![Docker Automated build](https://img.shields.io/docker/automated/bkimminich/juice-shop-ctf.svg)](https://hub.docker.com/r/bkimminich/juice-shop-ctf) [![Docker Pulls](https://img.shields.io/docker/pulls/bkimminich/juice-shop-ctf.svg)](https://hub.docker.com/r/bkimminich/juice-shop-ctf) ![Docker Stars](https://img.shields.io/docker/stars/bkimminich/juice-shop-ctf.svg) [![](https://images.microbadger.com/badges/image/bkimminich/juice-shop-ctf.svg)](https://microbadger.com/images/bkimminich/juice-shop-ctf "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/bkimminich/juice-shop-ctf.svg)](https://microbadger.com/images/bkimminich/juice-shop-ctf "Get your own version badge on microbadger.com")
 
 Share your current directory with the `/data` volume of your

--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ const argv = require('yargs')
     alias: 'o',
     describe: 'change the output file'
   })
+  .option('ignoreSslWarnings', {
+    alias: 'i',
+    describe: 'ignore tls certificate warnings'
+  })
   .help()
   .argv
 
@@ -94,10 +98,10 @@ const juiceShopCtfCli = async () => {
     console.log()
 
     const [fetchedSecretKey, challenges, countryMapping, vulnSnippets] = await Promise.all([
-      fetchSecretKey(answers.ctfKey),
-      fetchChallenges(answers.juiceShopUrl),
-      fetchCountryMapping(answers.countryMapping),
-      fetchCodeSnippets(answers.juiceShopUrl, answers.insertHintSnippets === options.noHintSnippets)
+      fetchSecretKey(answers.ctfKey, argv.ignoreSslWarnings),
+      fetchChallenges(answers.juiceShopUrl, argv.ignoreSslWarnings),
+      fetchCountryMapping(answers.countryMapping, argv.ignoreSslWarnings),
+      fetchCodeSnippets(answers.juiceShopUrl, argv.ignoreSslWarnings, answers.insertHintSnippets === options.noHintSnippets)
     ])
 
     await generateCtfExport(answers.ctfFramework || options.ctfdFramework, challenges, {

--- a/lib/fetchChallenges.js
+++ b/lib/fetchChallenges.js
@@ -6,9 +6,9 @@
 const Promise = require('bluebird')
 const request = require('request-promise')
 
-function fetchChallenges (juiceShopUrl) {
+function fetchChallenges (juiceShopUrl, ignoreSslWarnings) {
   return new Promise((resolve, reject) => {
-    request({ url: juiceShopUrl + '/api/Challenges', json: true }).then(({ data }) => {
+    request({ url: juiceShopUrl + '/api/Challenges', json: true, strictSSL: !ignoreSslWarnings }).then(({ data }) => {
       resolve(data)
     }).catch(({ message }) => {
       reject(new Error('Failed to fetch challenges from API! ' + message))

--- a/lib/fetchCodeSnippets.js
+++ b/lib/fetchCodeSnippets.js
@@ -5,14 +5,15 @@
 
 const request = require('request-promise')
 
-async function fetchCodeSnippets (juiceShopUrl, skip = false) {
+async function fetchCodeSnippets (juiceShopUrl, ignoreSslWarnings, skip = false) {
   if (skip) {
     return {}
   }
   try {
     const { challenges } = await request({
       url: juiceShopUrl + '/snippets',
-      json: true
+      json: true,
+      strictSSL: !ignoreSslWarnings
     })
     if (!challenges) {
       return {}
@@ -22,7 +23,8 @@ async function fetchCodeSnippets (juiceShopUrl, skip = false) {
       challenges.map(async (challengeKey) => {
         const { snippet } = await request({
           url: juiceShopUrl + '/snippets/' + challengeKey,
-          json: true
+          json: true,
+          strictSSL: !ignoreSslWarnings
         })
         return { challengeKey, snippet }
       })

--- a/lib/fetchCountryMapping.js
+++ b/lib/fetchCountryMapping.js
@@ -7,11 +7,11 @@ const Promise = require('bluebird')
 const request = require('request-promise')
 const yaml = Promise.promisifyAll(require('js-yaml'))
 
-function fetchChallenges (challengeMapFile) {
+function fetchChallenges (challengeMapFile, ignoreSslWarnings) {
   if (!challengeMapFile) {
     return Promise.resolve()
   }
-  return request({ url: challengeMapFile })
+  return request({ url: challengeMapFile, strictSSL: !ignoreSslWarnings })
     .then((data) => yaml.safeLoadAll(data))
     .then((data) => data[0].ctf.countryMapping)
     .catch(({ message }) => {

--- a/lib/fetchSecretKey.js
+++ b/lib/fetchSecretKey.js
@@ -7,10 +7,10 @@ const Promise = require('bluebird')
 const request = require('request-promise')
 const isUrl = require('./url')
 
-function fetchSecretKey (origin) {
+function fetchSecretKey (origin, ignoreSslWarnings) {
   return new Promise((resolve, reject) => {
     if (origin && isUrl(origin)) {
-      request(origin)
+      request({ url: origin, strictSSL: !ignoreSslWarnings })
         .then(body => {
           resolve(body)
         }).catch(({ message }) => {

--- a/test/e2e/juiceShopCtfCli-spec.js
+++ b/test/e2e/juiceShopCtfCli-spec.js
@@ -116,6 +116,19 @@ insertHintSnippets: paid`)
       .eventually.match(/Backup archive written to /i)
   })
 
+  it('should be able to ignore SslWarnings', function () {
+    fs.writeFileSync(configFile, `
+juiceShopUrl: https://juice-shop.herokuapp.com
+ctfKey: https://raw.githubusercontent.com/bkimminich/juice-shop/master/ctf.key
+insertHints: paid
+insertHintUrls: paid
+insertHintSnippets: paid`)
+
+    this.timeout(TIMEOUT)
+    return expect(execFile('node', [juiceShopCtfCli[0], '--config', configFile, '--ignoreSslWarnings']).then(obj => obj.stdout)).to
+      .eventually.match(/Backup archive written to /i)
+  })
+
   it('should fail when the config file cannot be parsed', function () {
     fs.writeFileSync(configFile, `
 juiceShopUrl: https://juice-shop.herokuapp.com

--- a/test/unit/fetchChallenges-spec.js
+++ b/test/unit/fetchChallenges-spec.js
@@ -14,7 +14,7 @@ describe('Challenges', () => {
   it('should be fetched from the given URL', () => {
     fetchChallenges.__set__({
       request (options) {
-        expect(options).to.deep.equal({ url: 'http://localhost:3000/api/Challenges', json: true })
+        expect(options).to.deep.equal({ url: 'http://localhost:3000/api/Challenges', strictSSL: true, json: true })
         return new Promise(resolve => { resolve({ data: { c1: { }, c2: { } } }) })
       }
     })

--- a/test/unit/fetchCodeSnippets-spec.js
+++ b/test/unit/fetchCodeSnippets-spec.js
@@ -17,10 +17,10 @@ describe('Code snippets', () => {
     fetchCodeSnippets.__set__({
       request (options) {
         if (options.url === 'http://localhost:3000/snippets') {
-          expect(options).to.deep.equal({ url: 'http://localhost:3000/snippets', json: true })
+          expect(options).to.deep.equal({ url: 'http://localhost:3000/snippets', json: true, strictSSL: true })
           return new Promise(resolve => { resolve({ challenges: ['c1'] }) })
         } else if (options.url === 'http://localhost:3000/snippets/c1') {
-          expect(options).to.deep.equal({ url: 'http://localhost:3000/snippets/c1', json: true })
+          expect(options).to.deep.equal({ url: 'http://localhost:3000/snippets/c1', json: true, strictSSL: true })
           return sleep(10).then(() => ({ snippet: 'function c1 () {}' }))
         } else {
           expect(false, 'Unexpected request: ' + options)


### PR DESCRIPTION
Ran into a situation where I had to fetch the flags but the certificate was not trusted by the Nodejs Runtime.

Did a fix, now you can add the --ignoreSslWarnings (or -i) command line parameter to ignore the certificate warning. Handy when your server is running with a self signed certificate.