### PR TITLE
FEATURE: Defining multiple flags in challenge for CTFd

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const questions = [
   {
     type: 'input',
     name: 'ctfKey',
-    message: 'Secret key <or> URL to ctf.key file?',
+    message: 'Secret key <or> URL to ctf.key file? (Note: for CTFd you can provide a comma-separated string for multiple flags)',
     default: 'https://raw.githubusercontent.com/bkimminich/juice-shop/master/ctf.key'
   },
   {

--- a/lib/generators/ctfd.js
+++ b/lib/generators/ctfd.js
@@ -40,7 +40,10 @@ function createCtfdExport (challenges, { insertHints, insertHintUrls, insertHint
   }
 */
 
-  return new Promise((resolve, reject) => {
+ // In the flags section of the returned data we iterate through the result of string splitting by comma, and compute the hash of the single flag key + challenge name.  
+ // Format expected is: challenge3,challenge description,category3,100,dynamic,visible,0,"flag1,flag2,flag3","tag1,tag2,tag3","hint1,hint2,hint3","{""initial"":100, ""minimum"":10, ""decay"":10}"
+ 
+ return new Promise((resolve, reject) => {
     try {
       const data = []
       for (const key in challenges) {
@@ -55,7 +58,7 @@ function createCtfdExport (challenges, { insertHints, insertHintUrls, insertHint
               type: 'standard',
               state: 'visible',
               max_attempts: 0,
-              flags: hmacSha1(ctfKey, challenge.name),
+              flags: `"${ctfKey.split(",").map(key => `${hmacSha1(key, challenge.name)}`).join(",")}"`,
               tags: challenge.tags ? `"${challenge.tags}"` : '',
               hints: insertChallengeHints(challenge),
               // hint_cost: insertChallengeHintCosts(challenge),


### PR DESCRIPTION
This is supposed to take care of the issue #129.

I have run all tests and the CTFd test currently fails because of the enclosing "s expected from CTFd for a multi-item record, should it be updated too?

I have manually tested the code through running a Docker instance of the Juice Shop to fetch the CTF challenges and generate a CTFd export with a comma-separated string as flag.