### PR TITLE
Fixed Docker container permission denied issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,6 @@ LABEL maintainer="Bjoern Kimminich <bjoern.kimminich@owasp.org>" \
 COPY --from=installer --chown=node /juice-shop-ctf /juice-shop-ctf
 VOLUME /data
 WORKDIR /data
+RUN chmod +x /juice-shop-ctf/bin/juice-shop-ctf.js
 USER node
 ENTRYPOINT ["npx", "/juice-shop-ctf/bin/juice-shop-ctf.js"]


### PR DESCRIPTION
As mentioned in #136, the application is currently broken when executed through Docker because of a Permission denied issue. 
Through adding +x perms to the image's entry point script, we manage to execute the application just fine.

The testing method used was running the same type of Docker run command mentioned in the issue, using a locally built image with the Dockerfile reflecting the changes that are pushed.  

![image](https://github.com/juice-shop/juice-shop-ctf/assets/43068342/34d171d0-e068-4cb9-b1ac-a3576caf8d05)
