### PR TITLE
Add paid hints back to CTFd exporter

### DIFF
--- a/lib/generators/ctfd.js
+++ b/lib/generators/ctfd.js
@@ -5,7 +5,7 @@
 
 const Promise = require('bluebird')
 const calculateScore = require('../calculateScore')
-// const calculateHintCost = require('../calculateHintCost')
+const calculateHintCost = require('../calculateHintCost')
 const hmacSha1 = require('../hmac')
 const options = require('../options')
 
@@ -21,10 +21,9 @@ function createCtfdExport (challenges, { insertHints, insertHintUrls, insertHint
     if (vulnSnippets[challenge.key] && insertHintSnippets !== options.noHintSnippets) {
       hints.push('<pre><code>' + vulnSnippets[challenge.key].replaceAll('"', '""').replaceAll(',', '٬') + '</code></pre>')
     }
-    return (hints.length === 0 ? '' : `"${hints.join(',')}"`)
+    return hints
   }
 
-  /*
   function insertChallengeHintCosts (challenge) {
     const hintCosts = []
     if (challenge.hint && insertHints !== options.noTextHints) {
@@ -36,9 +35,8 @@ function createCtfdExport (challenges, { insertHints, insertHintUrls, insertHint
     if (vulnSnippets[challenge.key] && insertHintSnippets !== options.noHintSnippets) {
       hintCosts.push(calculateHintCost(challenge, insertHintSnippets))
     }
-    return (hintCosts.length === 0 ? '' : `"${hintCosts.join(',')}"`)
+    return hintCosts
   }
-*/
 
   //  In the flags section of the returned data we iterate through the result of string splitting by comma, and compute the hash of the single flag key + challenge name.
   //  Format expected is: challenge3,challenge description,category3,100,dynamic,visible,0,"flag1,flag2,flag3","tag1,tag2,tag3","hint1,hint2,hint3","{""initial"":100, ""minimum"":10, ""decay"":10}"
@@ -49,22 +47,37 @@ function createCtfdExport (challenges, { insertHints, insertHintUrls, insertHint
       for (const key in challenges) {
         if (Object.prototype.hasOwnProperty.call(challenges, key)) {
           const challenge = challenges[key]
-          data.push(
-            {
-              name: challenge.name,
-              description: `"${challenge.description.replaceAll('"', '""')} (Difficulty Level: ${challenge.difficulty})"`,
-              category: challenge.category,
-              value: calculateScore(challenge.difficulty),
-              type: 'standard',
-              state: 'visible',
-              max_attempts: 0,
-              flags: ctfKey.split(',').length === 1 ? hmacSha1(ctfKey, challenge.name) : `"${ctfKey.split(',').map(key => `${hmacSha1(key, challenge.name)}`).join(',')}"`,
-              tags: challenge.tags ? `"${challenge.tags}"` : '',
-              hints: insertChallengeHints(challenge),
-              // hint_cost: insertChallengeHintCosts(challenge),
-              type_data: ''
+          const row = {
+            name: challenge.name,
+            description: `"${challenge.description.replaceAll('"', '""')} (Difficulty Level: ${challenge.difficulty})"`,
+            category: challenge.category,
+            value: calculateScore(challenge.difficulty),
+            type: 'standard',
+            state: 'visible',
+            max_attempts: 0,
+            flags: ctfKey.split(',').length === 1 ? hmacSha1(ctfKey, challenge.name) : `"${ctfKey.split(',').map(key => `${hmacSha1(key, challenge.name)}`).join(',')}"`,
+            tags: challenge.tags ? `"${challenge.tags}"` : '',
+            hints_raw: insertChallengeHints(challenge),
+            hint_cost: insertChallengeHintCosts(challenge),
+            type_data: ''
+          }
+          const hints = []
+          if (row.hints_raw.length !== 0) {
+            for (let index = 0; index < row.hints_raw.length; index++) {
+              const hint = {
+                content: row.hints_raw[index],
+                cost: row.hint_cost[index]
+              }
+              hints.push(hint)
             }
-          )
+            const hints_obj = JSON.stringify(hints).replace(/"/g, '""')
+            row.hints = `"${hints_obj}"`
+          } else {
+            row.hints = ''
+          }
+          delete row.hints_raw
+          delete row.hint_cost
+          data.push(row)
         }
       }
       resolve(data)


### PR DESCRIPTION
Hello! 

This PR adds back paid hints via CTFd's [JSON in CSV handling](https://github.com/CTFd/CTFd/blob/d7632b45422c93ace31dc52cff1702dbed305204/CTFd/utils/csv/__init__.py#L437-L440).

Admittedly I feel the JSON loading didn't work out as well as I had hoped for regular users but this works for a tool like juice-shop-ctf. 

Regular users generally want CSV importing so that they can use regular software to make challenges and the JSON loading doesn't let them do that so in the future maybe there could be work on a more in depth format but let me know if there are any concerns with this PR. 